### PR TITLE
Suggestions on improving the License UX

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,14 @@
-*This is a suggested `CONTRIBUTING.md` file template for use by open sourced Salesforce projects. The main goal of this file is to make clear the intents and expectations that end-users may have regarding this project and how/if to engage with it. Adjust as needed (especially look for `{project_slug}` which refers to the org and repo name of your project) and remove this paragraph before committing to your repo.*
+<!--
+This is a suggested `CONTRIBUTING.md` file template for use by open sourced Salesforce projects. The main goal of this file is to make clear the intents and expectations that end-users may have regarding this project and how/if to engage with it.
 
-# Contributing Guide For {NAME OF PROJECT}
+This guide is can be used without modification, but designed to be customized. See html comments for examples of how to make your project more welcoming to contributions. Specifically look for {project_slug} and replace it with the org and repo name of your project.
+-->
 
-This page lists the operational governance model of this project, as well as the recommendations and requirements for how to best contribute to {PROJECT}. We strive to obey these as best as possible. As always, thanks for contributing – we hope these guidelines make it easier and shed some light on our approach and processes.
+# Contributing Guide <!-- For {NAME OF PROJECT} -->
 
+This page lists recommendations and requirements for how to best contribute<!-- to {PROJECT} -->. We strive to obey these as best as possible. As always, thanks for contributing – we hope these guidelines make it easier and shed some light on our approach and processes.
+
+<!--
 # Governance Model
 > Pick the most appropriate one
 
@@ -22,31 +27,39 @@ The intent and goal of open sourcing this project is to increase the contributor
 ## Published but not supported
 
 The intent and goal of open sourcing this project is because it may contain useful or interesting code/concepts that we wish to share with the larger open source community. Although occasional work may be done on it, we will not be looking for or soliciting contributions.
+-->
 
+<!--
 # Getting started
 
+> List any additional community resources that might be helpful.
+
 Please join the community on {Here list Slack channels, Email lists, Glitter, Discord, etc... links}. Also please make sure to take a look at the project [roadmap](ROADMAP.md) to see where are headed.
+-->
 
 # Issues, requests & ideas
 
 Use GitHub Issues page to submit issues, enhancement requests and discuss ideas.
 
 ### Bug Reports and Fixes
--  If you find a bug, please search for it in the [Issues](https://github.com/{project_slug}/issues), and if it isn't already tracked,
-   [create a new issue](https://github.com/{project_slug}/issues/new). Fill out the "Bug Report" section of the issue template. Even if an Issue is closed, feel free to comment and add details, it will still
+
+-  If you find a bug, please search for it in the Issues <!-- [link](https://github.com/{project_slug}/issues) --> , and if it isn't already tracked,
+   create a new issue <!-- [link](https://github.com/{project_slug}/issues/new) -->. Fill out the "Bug Report" section of the issue template. Even if an Issue is closed, feel free to comment and add details, it will still
    be reviewed.
 -  Issues that have already been identified as a bug (note: able to reproduce) will be labelled `bug`.
 -  If you'd like to submit a fix for a bug, [send a Pull Request](#creating_a_pull_request) and mention the Issue number.
   -  Include tests that isolate the bug and verifies that it was fixed.
 
 ### New Features
--  If you'd like to add new functionality to this project, describe the problem you want to solve in a [new Issue](https://github.com/{project_slug}/issues/new).
+
+-  If you'd like to add new functionality to this project, describe the problem you want to solve in a new Issue <!-- [new Issue](https://github.com/{project_slug}/issues/new) -->.
 -  Issues that have been identified as a feature request will be labelled `enhancement`.
 -  If you'd like to implement the new feature, please wait for feedback from the project
    maintainers before spending too much time writing the code. In some cases, `enhancement`s may
    not align well with the project objectives at the time.
 
 ### Tests, Documentation, Miscellaneous
+
 -  If you'd like to improve the tests, you want to make the documentation clearer, you have an
    alternative implementation of something that may have advantages over the way its currently
    done, or you have any other change, we would be happy to hear about it!
@@ -85,9 +98,10 @@ Issues labelled `good first contribution`.
 
 > **NOTE**: Be sure to [sync your fork](https://help.github.com/articles/syncing-a-fork/) before making a pull request.
 
-
 # Code of Conduct
+
 Please follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 # License
+
 By contributing your code, you agree to license your contribution under the terms of our project [LICENSE](LICENSE.txt) and to sign the [Salesforce CLA](https://cla.salesforce.com/sign-cla)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Issues labelled `good first contribution`.
 
 1. **Ensure the bug/feature was not already reported** by searching on GitHub under Issues.  If none exists, create a new issue so that other contributors can keep track of what you are trying to add/fix and offer suggestions (or let you know if there is already an effort in progress).
 3. **Clone** the forked repo to your machine.
-4. **Create** a new branch to contain your work (e.g. `git br fix-issue-11`)
+4. **Create** a new branch to contain your work (e.g. `git branch fix-issue-11`)
 4. **Commit** changes to your own branch.
 5. **Push** your work back up to your fork. (e.g. `git push fix-issue-11`)
 6. **Submit** a Pull Request against the `main` branch and refer to the issue(s) you are fixing. Try not to pollute your pull request with unintended changes. Keep it simple and small.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,7 +3,7 @@ Apache License Version 2.0
 Copyright (c) 2024 Salesforce, Inc.
 All rights reserved.
 
-Apache License
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -179,29 +179,3 @@ Apache License
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Template files for open source projects at Salesforce. We suggest customizing th
 
 - CONTRIBUTING.md
 
-For more information about the license see [license_info.md](license_info.md).
+For more information about the license, see [license_info.md](license_info.md).
 
 ## Usage, automated
 
@@ -16,7 +16,7 @@ All files must be placed at the top level of your repository. Copy the following
 - LICENSE.txt
 - SECURITY.md
 
-This can be accomplished by runing these commands in a terminal that has [curl](https://curl.se/) installed:
+This task can be accomplished by running these commands in a terminal that has [curl](https://curl.se/) installed:
 
 ```term
 curl --remote-name --fail https://raw.githubusercontent.com/salesforce/oss-template/refs/heads/main/CODE_OF_CONDUCT.md &&
@@ -26,7 +26,7 @@ curl --remote-name --fail https://raw.githubusercontent.com/salesforce/oss-templ
 curl --remote-name --fail https://raw.githubusercontent.com/salesforce/oss-template/refs/heads/main/SECURITY.md
 ```
 
-Inspect the files, ensure the downloads succeeded (below `$` indicates a command was run in a terminal/command-prompt):
+Inspect the files, and ensure the downloads succeeded (below `$` indicates a command was run in a terminal/command prompt):
 
 ```term
 $ git status
@@ -40,11 +40,11 @@ Untracked files:
 	SECURITY.md
 ```
 
-Customize the following files with project specific information:
+Customize the following files with project-specific information:
 
 - CONTRIBUTING.md
 
-Replace lines containing HTML comments with the desired contents. For example if your project was named "V2MOM Analyzer" you could replace this:
+Replace lines containing HTML comments with the desired contents. For example, if your project was named "V2MOM Analyzer," you could replace this:
 
 ```
 # Contributing Guide <!-- For {NAME OF PROJECT} -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Salesforce OSS template
 
-Template files for open source projects at Salesforce. The following files need modification before use:
+Template files for open source projects at Salesforce. We suggest customizing the following files before use:
 
 - CONTRIBUTING.md
 
@@ -40,10 +40,20 @@ Untracked files:
 	SECURITY.md
 ```
 
-Update the following files with project specific information:
+Customize the following files with project specific information:
 
 - CONTRIBUTING.md
 
-Ensure placeholder brackets such as `{NAME OF PROJECT}` are replaced and that when multiple options are given such as `> or` that only one is selected.
+Replace lines containing HTML comments with the desired contents. For example if your project was named "V2MOM Analyzer" you could replace this:
+
+```
+# Contributing Guide <!-- For {NAME OF PROJECT} -->
+```
+
+With this:
+
+```
+# Contributing Guide V2MOM Analyzer
+```
 
 Commit the results to git.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,49 @@
-# README
+# Salesforce OSS template
 
-A repo containing all the basic file templates and general guidelines for any open source project at Salesforce.
+Template files for open source projects at Salesforce. The following files need modification before use:
 
-## Usage
+- CONTRIBUTING.md
 
-It's required that all files must be placed at the top level of your repository.
+For more information about the license see [license_info.md](license_info.md).
 
-> **NOTE** Your README should contain detailed, useful information about the project!
+## Usage, automated
 
+All files must be placed at the top level of your repository. Copy the following files into your project:
+
+- CODE_OF_CONDUCT.md
+- CODEOWNERS
+- CONTRIBUTING.md
+- LICENSE.txt
+- SECURITY.md
+
+This can be accomplished by runing these commands in a terminal that has [curl](https://curl.se/) installed:
+
+```term
+curl --remote-name --fail https://raw.githubusercontent.com/salesforce/oss-template/refs/heads/main/CODE_OF_CONDUCT.md &&
+curl --remote-name --fail https://raw.githubusercontent.com/salesforce/oss-template/refs/heads/main/CODEOWNERS
+curl --remote-name --fail https://raw.githubusercontent.com/salesforce/oss-template/refs/heads/main/CONTRIBUTING.md
+curl --remote-name --fail https://raw.githubusercontent.com/salesforce/oss-template/refs/heads/main/LICENSE.txt
+curl --remote-name --fail https://raw.githubusercontent.com/salesforce/oss-template/refs/heads/main/SECURITY.md
+```
+
+Inspect the files, ensure the downloads succeeded (below `$` indicates a command was run in a terminal/command-prompt):
+
+```term
+$ git status
+On branch main
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+	CODEOWNERS
+	CODE_OF_CONDUCT.md
+	CONTRIBUTING.md
+	LICENSE.txt
+	SECURITY.md
+```
+
+Update the following files with project specific information:
+
+- CONTRIBUTING.md
+
+Ensure placeholder brackets such as `{NAME OF PROJECT}` are replaced and that when multiple options are given such as `> or` that only one is selected.
+
+Commit the results to git.


### PR DESCRIPTION
## Problem

Current files in the project contain placeholders and other artifacts that are not intended to be used as-is. I accidentally used the existing LICENSE.txt without removing the placeholder section, and I found at least one other project that did the same https://github.com/salesforce/CodeGen/issues/95. Even after identifying that the file should not have placeholders, it was still not clear what desired outcome should look like (as noted by my strikethrough ~~strikethrough~~ suggestion from earlier on that repo). 

## Fix in this PR 

Make the templates valid by default, which allows them to be copied/pasted without modification. In addition, provide detailed install instructions to make doing the correct thing as easy and error-proof ass possible.

This change is possible by modifying the `LICENSE.txt` and `CONTRIBUTING.md` files. The `LICENSE.txt` now requires no placeholders. The `CONTRIBUTING.md` file now contains placeholders that can be updated as a form of "progressive enhancement". They are hidden by default and can be updated to improve the document, though the unmodified document should still be valid. 

## Meta

Close https://github.com/salesforce/oss-template/issues/16. Commits are written to be reviewed (roughly independently) in sequential order. 