### PR TITLE
Refer to "project" instead of "library" in `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 ## Security
 
 Please report any security issue to [https://www.sfdc.co/SubmitVuln](https://www.sfdc.co/SubmitVuln)
-as soon as it is discovered. This library limits its runtime dependencies in
+as soon as it is discovered. This project limits its runtime dependencies in
 order to reduce the total cost of ownership as much as can be, but all consumers
 should remain vigilant and have their security stakeholders review all third-party
 products (3PP) like this one and their dependencies.


### PR DESCRIPTION
Since not every OSS repo will be that of a library - the term "project" is more generic and will cover not only libraries, but things like buildpacks, example apps, documentation etc.