### PR TITLE
Fix typos, markdown and whitespace in `CODE_OF_CONDUCT.md`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,8 +8,8 @@ culture where everyone feels included.
 
 Salesforce open-source projects are committed to providing a friendly, safe, and
 welcoming environment for all, regardless of gender identity and expression,
-sexual orientation, disability, physical appearance, body size, ethnicity, nationality, 
-race, age, religion, level of experience, education, socioeconomic status, or 
+sexual orientation, disability, physical appearance, body size, ethnicity, nationality,
+race, age, religion, level of experience, education, socioeconomic status, or
 other similar personal characteristics.
 
 The goal of this code of conduct is to specify a baseline standard of behavior so
@@ -25,9 +25,9 @@ Open Source Conduct Committee at ossconduct@salesforce.com.
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of gender 
-identity and expression, sexual orientation, disability, physical appearance, 
-body size, ethnicity, nationality, race, age, religion, level of experience, education, 
+our community a harassment-free experience for everyone, regardless of gender
+identity and expression, sexual orientation, disability, physical appearance,
+body size, ethnicity, nationality, race, age, religion, level of experience, education,
 socioeconomic status, or other similar personal characteristics.
 
 ## Our Standards
@@ -77,28 +77,28 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the Salesforce Open Source Conduct Committee 
-at ossconduct@salesforce.com. All complaints will be reviewed and investigated 
-and will result in a response that is deemed necessary and appropriate to the 
-circumstances. The committee is obligated to maintain confidentiality with 
-regard to the reporter of an incident. Further details of specific enforcement 
+reported by contacting the Salesforce Open Source Conduct Committee
+at ossconduct@salesforce.com. All complaints will be reviewed and investigated
+and will result in a response that is deemed necessary and appropriate to the
+circumstances. The committee is obligated to maintain confidentiality with
+regard to the reporter of an incident. Further details of specific enforcement
 policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership and the Salesforce Open Source Conduct 
+members of the project's leadership and the Salesforce Open Source Conduct
 Committee.
 
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][contributor-covenant-home],
-version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html. 
-It includes adaptions and additions from [Go Community Code of Conduct][golang-coc], 
+version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html.
+It includes adaptations and additions from [Go Community Code of Conduct][golang-coc],
 [CNCF Code of Conduct][cncf-coc], and [Microsoft Open Source Code of Conduct][microsoft-coc].
 
 This Code of Conduct is licensed under the [Creative Commons Attribution 3.0 License][cc-by-3-us].
 
-[contributor-covenant-home]: https://www.contributor-covenant.org (https://www.contributor-covenant.org/)
+[contributor-covenant-home]: https://www.contributor-covenant.org
 [golang-coc]: https://golang.org/conduct
 [cncf-coc]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
 [microsoft-coc]: https://opensource.microsoft.com/codeofconduct/


### PR DESCRIPTION
- `s/adaptions/adaptations/`
- Fixes markdown URL
- Removes trailing whitespace at end of some lines.