### PR TITLE
Fix heading depth in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-## Security
+# Security
 
 Please report any security issue to [https://www.sfdc.co/SubmitVuln](https://www.sfdc.co/SubmitVuln)
 as soon as it is discovered. This project limits its runtime dependencies in


### PR DESCRIPTION
The main heading was previously using H2 rather than H1, even though it's the first/only heading.